### PR TITLE
feat: webhook channel query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ webhook endpoint, whenever a new image is pushed.
 ## Webhook
 
 In servermode Kobold exposes a webhook endpoint at
-`$KOBOLD_ADDR_WEBHOOK/events?chan=<channel>`. The channel is used to identify
+`$KOBOLD_ADDR_WEBHOOK/events/<channel>`. The channel is used to identify
 the pipelines to run. It accepts any content in the body since it is the
 [channels decoder's](#decoders) responsibility to parse the body.
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -86,7 +86,18 @@ func run(ctx context.Context, args []string, env []string) error {
 
 	g.Go(func() error {
 		whmux := http.NewServeMux()
-		whmux.Handle(prefix+"/events", http.StripPrefix(prefix, webhook.New(sched)))
+
+		eventHandler := http.StripPrefix(prefix, webhook.New(sched))
+
+		// CASE: When the event is being received at '/events/<channel-name>' and the channel name
+		// gets extracted from the path parameter.
+		whmux.Handle(prefix+"/events/{chan}", eventHandler)
+
+		// DEPRECATED.
+		// CASE: When the event is being received at '/events' and the channel name gets extracted
+		// from the 'chan' query parameter.
+		whmux.Handle(prefix+"/events", eventHandler)
+
 		return listenAndServeContext(ctx, "webhook", webhookAddr, whmux)
 	})
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bluebrown/kobold/store"
 	"github.com/bluebrown/kobold/store/schema"
 	"github.com/bluebrown/kobold/task"
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/errgroup"
 	_ "modernc.org/sqlite"
@@ -85,7 +86,7 @@ func run(ctx context.Context, args []string, env []string) error {
 	})
 
 	g.Go(func() error {
-		whmux := http.NewServeMux()
+		whmux := mux.NewRouter()
 
 		eventHandler := http.StripPrefix(prefix, webhook.New(sched))
 
@@ -96,7 +97,7 @@ func run(ctx context.Context, args []string, env []string) error {
 		// DEPRECATED.
 		// CASE: When the event is being received at '/events' and the channel name gets extracted
 		// from the 'chan' query parameter.
-		whmux.Handle(prefix+"/events", eventHandler)
+		whmux.Handle(prefix+"/events", eventHandler).Queries("chan", "{chan}")
 
 		return listenAndServeContext(ctx, "webhook", webhookAddr, whmux)
 	})

--- a/http/webhook/handler.go
+++ b/http/webhook/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/bluebrown/kobold/task"
+	"github.com/gorilla/mux"
 )
 
 type Webhook struct {
@@ -23,7 +24,18 @@ func (api *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unable to read body", http.StatusBadRequest)
 		return
 	}
-	if err := api.s.Schedule(r.Context(), r.URL.Query().Get("chan"), buf.Bytes()); err != nil {
+
+	var channelName string
+
+	// Try to get the channel name from the path parameter. If not found in the path parameter, then
+	// get it from the query parameter.
+	muxVars := mux.Vars(r)
+	channelName = muxVars["chan"]
+	if len(channelName) == 0 {
+		channelName = r.URL.Query().Get("chan")
+	}
+
+	if err := api.s.Schedule(r.Context(), channelName, buf.Bytes()); err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/http/webhook/handler_test.go
+++ b/http/webhook/handler_test.go
@@ -1,0 +1,73 @@
+package webhook
+
+import (
+	"context"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestWebhook_ServeHTTP(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		giveUrl     string
+		giveBody    string
+		wantStatus  int
+		wantResBody string
+		wantChan    string
+	}{
+		{
+			name:        "query parameter",
+			giveUrl:     "/events?chan=query",
+			giveBody:    "hello",
+			wantStatus:  200,
+			wantResBody: warnQueryDeprecated,
+			wantChan:    "query",
+		},
+		{
+			name:       "path parameter",
+			giveUrl:    "/events/path",
+			giveBody:   "hello",
+			wantStatus: 202,
+			wantChan:   "path",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var (
+				ms  = mockScheduler{}
+				api = New(&ms)
+				rec = httptest.NewRecorder()
+				req = httptest.NewRequest("POST", tt.giveUrl, strings.NewReader(tt.giveBody))
+			)
+			api.ServeHTTP(rec, req)
+			res := rec.Result()
+			assertEq(t, res.StatusCode, tt.wantStatus)
+			assertEq(t, rec.Body.String(), tt.wantResBody)
+			assertEq(t, ms.ch, tt.wantChan)
+			assertEq(t, string(ms.buf), tt.giveBody)
+		})
+	}
+}
+
+type mockScheduler struct {
+	ch  string
+	buf []byte
+}
+
+func (m *mockScheduler) Schedule(ctx context.Context, chn string, data []byte) error {
+	m.ch = chn
+	m.buf = data
+	return nil
+}
+
+func assertEq[T any](t *testing.T, got, want T) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/http/webhook/handler_test.go
+++ b/http/webhook/handler_test.go
@@ -12,7 +12,7 @@ func TestWebhook_ServeHTTP(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name        string
-		giveUrl     string
+		giveURL     string
 		giveBody    string
 		wantStatus  int
 		wantResBody string
@@ -20,7 +20,7 @@ func TestWebhook_ServeHTTP(t *testing.T) {
 	}{
 		{
 			name:        "query parameter",
-			giveUrl:     "/events?chan=query",
+			giveURL:     "/events?chan=query",
 			giveBody:    "hello",
 			wantStatus:  200,
 			wantResBody: warnQueryDeprecated,
@@ -28,7 +28,7 @@ func TestWebhook_ServeHTTP(t *testing.T) {
 		},
 		{
 			name:       "path parameter",
-			giveUrl:    "/events/path",
+			giveURL:    "/events/path",
 			giveBody:   "hello",
 			wantStatus: 202,
 			wantChan:   "path",
@@ -42,10 +42,11 @@ func TestWebhook_ServeHTTP(t *testing.T) {
 				ms  = mockScheduler{}
 				api = New(&ms)
 				rec = httptest.NewRecorder()
-				req = httptest.NewRequest("POST", tt.giveUrl, strings.NewReader(tt.giveBody))
+				req = httptest.NewRequest("POST", tt.giveURL, strings.NewReader(tt.giveBody))
 			)
 			api.ServeHTTP(rec, req)
 			res := rec.Result()
+			defer res.Body.Close()
 			assertEq(t, res.StatusCode, tt.wantStatus)
 			assertEq(t, rec.Body.String(), tt.wantResBody)
 			assertEq(t, ms.ch, tt.wantChan)
@@ -59,7 +60,7 @@ type mockScheduler struct {
 	buf []byte
 }
 
-func (m *mockScheduler) Schedule(ctx context.Context, chn string, data []byte) error {
+func (m *mockScheduler) Schedule(_ context.Context, chn string, data []byte) error {
 	m.ch = chn
 	m.buf = data
 	return nil


### PR DESCRIPTION
Fixes #39 

Events can now be received at both `/events` or `/events/<channel-name>` endpoints