### PR TITLE
feat(filter): handle 'tag only' fields

### DIFF
--- a/krm/comment.go
+++ b/krm/comment.go
@@ -15,13 +15,17 @@ const (
 )
 
 const (
-	KeyType = "type"
-	KeyTag  = "tag"
+	KeyType    = "type"
+	KeyTag     = "tag"
+	KeyPart    = "part"
+	KeyContext = "context"
 )
 
 type Options struct {
-	Type string
-	Tag  string
+	Type    string
+	Tag     string
+	Part    string
+	Context string
 }
 
 func ParseOpts(expr string) (Options, error) {
@@ -37,6 +41,10 @@ func ParseOpts(expr string) (Options, error) {
 			opts.Type = strings.TrimSpace(v)
 		case KeyTag:
 			opts.Tag = strings.TrimSpace(v)
+		case KeyPart:
+			opts.Part = strings.TrimSpace(v)
+		case KeyContext:
+			opts.Context = strings.TrimSpace(v)
 		default:
 			return opts, fmt.Errorf("unknown key: %s", v)
 		}

--- a/krm/filter.go
+++ b/krm/filter.go
@@ -13,7 +13,11 @@ func DefaultNodeHandler(_, currentRef, nextRef string, opts Options) (string, er
 		return currentRef, nil
 	}
 
-	oldRef, err := name.ParseReference(currentRef)
+	fullRef := currentRef
+	if opts.Part == "tag" {
+		fullRef = fmt.Sprintf("%s:%s", opts.Context, currentRef)
+	}
+	oldRef, err := name.ParseReference(fullRef)
 	if err != nil {
 		return currentRef, err
 	}
@@ -40,6 +44,9 @@ func DefaultNodeHandler(_, currentRef, nextRef string, opts Options) (string, er
 		return currentRef, err
 	}
 
+	if opts.Part == "tag" {
+		return newRef.Identifier(), nil
+	}
 	return nextRef, nil
 }
 

--- a/krm/filter_test.go
+++ b/krm/filter_test.go
@@ -215,6 +215,22 @@ func Test_renderer_Render(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "argocd",
+			giveDir: "argocd",
+			giveEvents: []string{
+				"docker.io/foo/baz:1.0.1@sha256:220611111e8c9bbe242e9dc1367c0fa89eef83f26203ee3f7c3764046e02b248",
+			},
+			wantSourceFieldValue: map[string][]wantFieldValue{
+				"application.yaml": {
+					{
+						rnodeIndex: 0,
+						field:      "spec.source.helm.valuesObject.image.tag",
+						value:      "1.0.1",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/krm/filter_test.go
+++ b/krm/filter_test.go
@@ -220,6 +220,7 @@ func Test_renderer_Render(t *testing.T) {
 			giveDir: "argocd",
 			giveEvents: []string{
 				"docker.io/foo/baz:1.0.1@sha256:220611111e8c9bbe242e9dc1367c0fa89eef83f26203ee3f7c3764046e02b248",
+				"docker.io/foo/bar:master-124-012345@sha256:220611111e8c9bbe242e9dc1367c0fa89eef83f26203ee3f7c3764046e02b248",
 			},
 			wantSourceFieldValue: map[string][]wantFieldValue{
 				"application.yaml": {
@@ -227,6 +228,11 @@ func Test_renderer_Render(t *testing.T) {
 						rnodeIndex: 0,
 						field:      "spec.source.helm.valuesObject.image.tag",
 						value:      "1.0.1",
+					},
+					{
+						rnodeIndex: 1,
+						field:      "spec.source.helm.valuesObject.image.tag",
+						value:      "master-124-012345",
 					},
 				},
 			},

--- a/krm/testdata/argocd/application.yaml
+++ b/krm/testdata/argocd/application.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: testcase
+spec:
+  project: testcase
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: testcase
+  source:
+    chart: testcase
+    repoURL: https://example.com/testcase
+    targetRevision: 1.0.0
+    helm:
+      releaseName: testcase
+      valuesObject:
+        image:
+          tag: "1.0"  # kobold: tag: ^1; type: semver; part: tag; context: docker.io/foo/baz

--- a/krm/testdata/argocd/application.yaml
+++ b/krm/testdata/argocd/application.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: testcase
+  name: testcase1
 spec:
   project: testcase
   destination:
@@ -17,3 +17,22 @@ spec:
       valuesObject:
         image:
           tag: "1.0"  # kobold: tag: ^1; type: semver; part: tag; context: docker.io/foo/baz
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: testcase2
+spec:
+  project: testcase
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: testcase
+  source:
+    chart: testcase
+    repoURL: https://example.com/testcase
+    targetRevision: 1.0.0
+    helm:
+      releaseName: testcase
+      valuesObject:
+        image:
+          tag: "master-123-abcdef0"  # kobold: tag: master-(\d+)-.*; type: regex; part: tag; context: docker.io/foo/bar


### PR DESCRIPTION
Add ability to update fields that contain only an image tag, not a full image ref.

https://github.com/bluebrown/kobold/issues/19