### PR TITLE
fix(filter): false positive change reports due to context

### DIFF
--- a/krm/filter.go
+++ b/krm/filter.go
@@ -132,12 +132,7 @@ func (i *ImageRefUpdateFilter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error
 			lastChange = change
 		}
 
-		newValue := mn.Value.YNode().Value
-		if opts.Context != "" {
-			newValue = fmt.Sprintf("%s:%s", opts.Context, newValue)
-		}
-
-		if originalValue != newValue {
+		if originalValue != mn.Value.YNode().Value {
 			i.Changes = append(i.Changes, lastChange)
 		}
 

--- a/krm/testdata/parts-no-change/stuff.yaml
+++ b/krm/testdata/parts-no-change/stuff.yaml
@@ -1,0 +1,1 @@
+none: no # kobold: tag: no; type: exact; part: tag; context: docker.io/foo/baz


### PR DESCRIPTION
Kobold might emit false positives in the changes slice, when using context in combination with no matching tag.

The issue should not impact users in a meaningful way. If there are real changes, there might be a bogus item in the commit message. If there are no changes at all, kobold should fail for that task to commit.

However, this PR fixes the false positives.