### PR TITLE
Improve commit messages to include change detail.

### DIFF
--- a/task/handler.go
+++ b/task/handler.go
@@ -47,7 +47,7 @@ func KoboldHandler(ctx context.Context, cache string, g model.TaskGroup, runner 
 
 	msg, err = GetCommitMessage(changes)
 	if err != nil {
-		msg = "chore(kobold): Update image refs"
+		return nil, fmt.Errorf("unable to get commit message: %w", err)
 	}
 
 	if err := git.Publish(ctx, cache, g.DestBranch.String, msg); err != nil {
@@ -71,19 +71,18 @@ func GetCommitMessage(changes []krm.Change) (string, error) {
 	seen := make(map[string]struct{})
 
 	msg := strings.Builder{}
-	msg.WriteString("chore(kobold): ")
+	msg.WriteString("chore(kobold):\n")
 
 	for _, change := range changes {
 		if _, ok := seen[change.Repo]; ok {
 			continue
 		}
-		msg.WriteString(change.Repo)
-		msg.WriteString(", ")
+		msg.WriteString(fmt.Sprintf(" * %s: %s\n", change.Repo, change.Description))
 
 		seen[change.Repo] = struct{}{}
 	}
 
-	return msg.String()[:msg.Len()-2], nil
+	return msg.String()[:msg.Len()-1], nil
 }
 
 var _ Handler = KoboldHandler

--- a/task/handler_test.go
+++ b/task/handler_test.go
@@ -26,7 +26,7 @@ func TestGetCommitMessage(t *testing.T) {
 					},
 				},
 			},
-			want:    "chore(kobold): busybox",
+			want:    "chore(kobold):\n * busybox: busybox:1.0.0 -> busybox:1.0.1",
 			wantErr: false,
 		},
 		{
@@ -43,7 +43,7 @@ func TestGetCommitMessage(t *testing.T) {
 					},
 				},
 			},
-			want:    "chore(kobold): busybox, somerepo",
+			want:    "chore(kobold):\n * busybox: busybox:1.0.0 -> busybox:1.0.1\n * somerepo: somerepo:2.0.0 -> somerepo:2.0.1",
 			wantErr: false,
 		},
 		{
@@ -60,7 +60,7 @@ func TestGetCommitMessage(t *testing.T) {
 					},
 				},
 			},
-			want:    "chore(kobold): busybox",
+			want:    "chore(kobold):\n * busybox: busybox:1.0.0 -> busybox:1.0.1",
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
1) When there is an issue creating the git commit message, it is using an ambiguous commit message and discarding the error.

This PR updates it to better handle (i.e. report) the error so any potential causes can be addressed.

2) The existing git commit message was ridiculously ambiguous, lacking any useful detail. Multiple commits to the same repo would simply yield the same commit message each time.

This PR updates the git commit message to include more detail including the 'from' (curr) and 'to' (next) tags, so we can see from the commit history what changed, without having to drill into the content of each patch.