### PR TITLE
fix: handle commit message format errors

### DIFF
--- a/task/handler_test.go
+++ b/task/handler_test.go
@@ -66,7 +66,7 @@ func TestGetCommitMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetCommitMessage(tt.args.changes)
+			got, err := commitMessage(tt.args.changes)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetCommitMessage() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
fix: #66 
resolve: #68 

Check and return error from commit message function. 