### PR TITLE
fix: Main commit message

### DIFF
--- a/task/handler.go
+++ b/task/handler.go
@@ -71,7 +71,7 @@ func commitMessage(changes []krm.Change) (string, error) {
 	seen := make(map[string]struct{})
 
 	msg := strings.Builder{}
-	if _, err := msg.WriteString("chore(kobold):\n"); err != nil {
+	if _, err := msg.WriteString("chore(kobold): Update image refs\n"); err != nil {
 		return "", fmt.Errorf("write header: %w", err)
 	}
 

--- a/task/handler_test.go
+++ b/task/handler_test.go
@@ -26,7 +26,7 @@ func TestGetCommitMessage(t *testing.T) {
 					},
 				},
 			},
-			want:    "chore(kobold):\n * busybox: busybox:1.0.0 -> busybox:1.0.1",
+			want:    "chore(kobold): Update image refs\n * busybox: busybox:1.0.0 -> busybox:1.0.1",
 			wantErr: false,
 		},
 		{
@@ -43,7 +43,7 @@ func TestGetCommitMessage(t *testing.T) {
 					},
 				},
 			},
-			want:    "chore(kobold):\n * busybox: busybox:1.0.0 -> busybox:1.0.1\n * somerepo: somerepo:2.0.0 -> somerepo:2.0.1",
+			want:    "chore(kobold): Update image refs\n * busybox: busybox:1.0.0 -> busybox:1.0.1\n * somerepo: somerepo:2.0.0 -> somerepo:2.0.1",
 			wantErr: false,
 		},
 		{
@@ -60,7 +60,7 @@ func TestGetCommitMessage(t *testing.T) {
 					},
 				},
 			},
-			want:    "chore(kobold):\n * busybox: busybox:1.0.0 -> busybox:1.0.1",
+			want:    "chore(kobold): Update image refs\n * busybox: busybox:1.0.0 -> busybox:1.0.1",
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
I found that commit description is filled in, but the main message was "chore(kobold)\n" which made me think the bug in #66 was still happening. I think setting it to the original "chore(kobold): Update image refs" is appropriate since the commit description now contains the updated images.