### PR TITLE
fix(git): serialize concurrent pushes and refresh refs to avoid stale state

### DIFF
--- a/git/bindings.go
+++ b/git/bindings.go
@@ -58,6 +58,16 @@ func Ensure(ctx context.Context, dir, uri string, refs ...string) error {
 	return nil
 }
 
+// refresh fetches the latest state of a ref from origin (shallow, depth 1).
+// This should be called before updating a ref that may have been modified
+// by other concurrent tasks, to avoid stale local state.
+func Refresh(ctx context.Context, dir, ref string) error {
+	if err := FetchShallow(ctx, dir, ref); err != nil {
+		return fmt.Errorf("git fetch refresh: %w", err)
+	}
+	return nil
+}
+
 // switch to ref. This should be called after Ensure
 // to get a writeable branch.
 func Switch(ctx context.Context, dir, ref string) error {

--- a/task/handler.go
+++ b/task/handler.go
@@ -22,6 +22,13 @@ func KoboldHandler(ctx context.Context, cache string, g model.TaskGroup, runner 
 		msg      string
 	)
 
+	// Refresh the source ref to ensure we have the latest remote state.
+	// This is critical when multiple tasks target the same repo+ref,
+	// to avoid stale local state that causes push rejections.
+	if err := git.Refresh(ctx, cache, g.RepoUri.Ref); err != nil {
+		return nil, fmt.Errorf("git refresh: %#q => %#q: %w", g.RepoUri.Repo, g.RepoUri.Ref, err)
+	}
+
 	if err := git.Switch(ctx, cache, g.RepoUri.Ref); err != nil {
 		return nil, fmt.Errorf("git switch: %#q => %#q: %w", g.RepoUri.Repo, g.RepoUri.Ref, err)
 	}

--- a/task/pool.go
+++ b/task/pool.go
@@ -42,6 +42,10 @@ type Pool struct {
 	cancel     context.CancelFunc
 	size       int
 	cache      *git.RepoCache
+	// pushLocks serializes the handler (fetch→commit→push) per repo:ref pair,
+	// preventing concurrent goroutines from racing on the same remote branch.
+	pushLocks sync.Map
+
 }
 
 func NewPool(ctx context.Context, size int, queries *model.Queries) *Pool {
@@ -146,6 +150,13 @@ func (p *Pool) Dispatch() error {
 				reason string
 				warns  []string
 			)
+
+			// Serialize the full handler execution per repo:ref to prevent
+			// concurrent goroutines from racing on git push to the same branch.
+			lockKey := g.RepoUri.Repo + ":" + g.RepoUri.Ref
+			mu, _ := p.pushLocks.LoadOrStore(lockKey, &sync.Mutex{})
+			mu.(*sync.Mutex).Lock()
+			defer mu.(*sync.Mutex).Unlock()
 
 			if path, err := p.cache.Get(p.ctx, ns, g.RepoUri.Repo); err == nil && p.handler != nil {
 				warns, err = p.handler(p.ctx, path, g, p.hookRunner)


### PR DESCRIPTION
This pull request improves the reliability of concurrent git operations by ensuring that each repo and ref pair is handled safely, preventing race conditions and stale state issues. The most important changes are:

**Concurrency control for git operations:**

* Introduced a `pushLocks` field in the `Pool` struct to serialize handler execution per `repo:ref` pair, preventing concurrent goroutines from racing on git push to the same branch. (`task/pool.go`)
* In the `Dispatch` method, added logic to acquire and release a mutex for each `repo:ref` pair, ensuring that only one handler operates on a given branch at a time. (`task/pool.go`)

**Ensuring up-to-date git state:**

* Added a new `Refresh` function to the git bindings that fetches the latest state of a ref from origin (shallow, depth 1), to avoid using stale local state. (`git/bindings.go`)
* In the `KoboldHandler`, now calls `git.Refresh` before switching branches to ensure the latest remote state is fetched, reducing the risk of push rejections due to outdated data. (`task/handler.go`)

related to issue fixes #71 